### PR TITLE
Reorder sections in oh-my-zsh.sh to fix python & venv issues

### DIFF
--- a/oh-my-zsh.sh
+++ b/oh-my-zsh.sh
@@ -192,25 +192,6 @@ _omz_source() {
   fi
 }
 
-# Load all of the lib files in ~/.oh-my-zsh/lib that end in .zsh
-# TIP: Add files you don't want in git to .gitignore
-for lib_file ("$ZSH"/lib/*.zsh); do
-  _omz_source "lib/${lib_file:t}"
-done
-unset lib_file
-
-# Load all of the plugins that were defined in ~/.zshrc
-for plugin ($plugins); do
-  _omz_source "plugins/$plugin/$plugin.plugin.zsh"
-done
-unset plugin
-
-# Load all of your custom configurations from custom/
-for config_file ("$ZSH_CUSTOM"/*.zsh(N)); do
-  source "$config_file"
-done
-unset config_file
-
 # Load the theme
 is_theme() {
   local base_dir=$1
@@ -229,6 +210,25 @@ if [[ -n "$ZSH_THEME" ]]; then
     echo "[oh-my-zsh] theme '$ZSH_THEME' not found"
   fi
 fi
+
+# Load all of the lib files in ~/.oh-my-zsh/lib that end in .zsh
+# TIP: Add files you don't want in git to .gitignore
+for lib_file ("$ZSH"/lib/*.zsh); do
+  _omz_source "lib/${lib_file:t}"
+done
+unset lib_file
+
+# Load all of the plugins that were defined in ~/.zshrc
+for plugin ($plugins); do
+  _omz_source "plugins/$plugin/$plugin.plugin.zsh"
+done
+unset plugin
+
+# Load all of your custom configurations from custom/
+for config_file ("$ZSH_CUSTOM"/*.zsh(N)); do
+  source "$config_file"
+done
+unset config_file
 
 # set completion colors to be the same as `ls`, after theme has been loaded
 [[ -z "$LS_COLORS" ]] || zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Move the theme section above the plugin section in oh-my-zsh.sh so the plugins (ex. python) can save the correct $PS1
- Does not add any new code, just reorders sections

## Other comments:

This fixes the various prompt/python/venv issues several people have made issues for, mentioned here:

> Hi! This is a known issue, and it is expected. The way python venv work this shit out is very bad.
> It is a duplicate of #12599, see https://github.com/ohmyzsh/ohmyzsh/issues/12599#issuecomment-2287935144 

 _Originally posted by @carlosala in [#12715](https://github.com/ohmyzsh/ohmyzsh/issues/12715#issuecomment-2400693285)_
